### PR TITLE
Configure dogevcoin chain parameters

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -5,7 +5,7 @@ const networks = require('../src/network')
 
 const cli = meow(`
     !!! Important !!!
-    This is a beta version. It only support regtest and testnet network.
+    This is a beta version. It supports regtest, testnet, and dogeev networks.
   
     Usage
       $ dogecoin-spv <command>
@@ -16,6 +16,7 @@ const cli = meow(`
     Options
       --regtest, -r  Start in regtest mode
       --dev, -d      Start node as dev (local data folder and not user)
+      --dogeev, -e   Start in dogeev mode
 
     Examples
       $ dogecoin-spv start --regtest
@@ -25,6 +26,10 @@ const cli = meow(`
     regtest: {
       type: 'boolean',
       alias: 'r'
+    },
+    dogeev: {
+      type: 'boolean',
+      alias: 'e'
     },
     dev: {
       type: 'boolean',
@@ -41,6 +46,10 @@ let network = networks.TESTNET
 
 if (cli.flags.regtest) {
   network = networks.REGTEST
+}
+
+if (cli.flags.dogeev) {
+  network = networks.DOGEEV
 }
 
 app({ network, dev: cli.flags.dev })

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,12 +63,33 @@ const constants = {
     PAYMENT_CHANNEL_URLS: [
       ''
     ]
+  },
+  dogeev: {
+    DATA_SUBFOLDER: 'dogeev',
+    MAGIC_BYTES: 0xc3c2c1c0,
+    GENESIS_BLOCK_HASH: '1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691',
+    PREVIOUS_HEADER: '9156352c1818b32e90c9e792efd6a11a82fe7956a630f03bbee236cedae3911a',
+    DNS_SEED: ['dnsseed.junkcoinexplorer.com', 'dogeevseed.s3na.xyz'],
+    DEFAULT_PORT: 42069,
+    NETWORK_BYTE: '1e',
+    SCRIPT_BYTE: '16',
+    PATH: '44\'/3\'/0\'/',
+    WALLET: {
+      wif: 0x9E,
+      bip32: {
+        public: 0x02FACAFD,
+        private: 0x02FAC398
+      }
+    },
+    PAYMENT_CHANNEL_URLS: [
+      ''
+    ]
   }
 }
 
 module.exports = {
   constants,
   KOINU: 100000000n,
-  PROTOCOL_VERSION: 70004,
+  PROTOCOL_VERSION: 70015,
   MIN_FEE: 1n
 }

--- a/src/network.js
+++ b/src/network.js
@@ -1,7 +1,8 @@
 const networks = {
   REGTEST: 'regtest',
   TESTNET: 'testnet',
-  MAINNET: 'mainnet'
+  MAINNET: 'mainnet',
+  DOGEEV: 'dogeev'
 }
 
 module.exports = networks

--- a/src/settings.js
+++ b/src/settings.js
@@ -14,6 +14,9 @@ function getSettings (network, dev) {
     case networks.TESTNET:
       settings = constants.testnet
       break
+    case networks.DOGEEV:
+      settings = constants.dogeev
+      break
     case networks.MAINNET:
       throw new MainnetNotSupported()
     default:


### PR DESCRIPTION
Add support for the 'dogeev' blockchain network to integrate custom chain parameters.

This PR integrates the user-provided Dogevcoin chain parameters, including custom magic bytes, default port, genesis block hash, DNS seeds, and base58 address prefixes. It also introduces a `--dogeev` CLI flag for easy network selection and updates the `PROTOCOL_VERSION` to 70015 for compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-e95a0ded-bf64-4390-a612-a533970bb11a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e95a0ded-bf64-4390-a612-a533970bb11a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

